### PR TITLE
Add support for using values from the custom key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eighteen73/tailwindcss-wordpress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tailwind CSS WordPress Utilities",
   "license": "MIT",
   "main": "index.js",

--- a/src/themeJson.js
+++ b/src/themeJson.js
@@ -16,13 +16,20 @@ module.exports = function (
 ) {
 	const values = {};
 	const setting = get(json, themeKey);
+	const custom = themeKey.includes('custom');
 
-	if (setting) {
+	if (Array.isArray(setting)) {
 		setting.forEach((item) => {
 			const { slug } = item;
 			const cssProperty = getCssProperty(themeKey);
 			values[slug] = toVariable(cssProperty, toSlug(slug));
 		});
+	} else {
+		for (const item in setting) {
+			const slug = item;
+			const cssProperty = getCssProperty(themeKey);
+			values[slug] = toVariable(cssProperty, toSlug(slug), custom);
+		}
 	}
 
 	return values;

--- a/src/util/toVariable.js
+++ b/src/util/toVariable.js
@@ -2,10 +2,12 @@
  *
  * Convert a given key and value to a WordPress CSS variable.
  *
- * @param {string} key   The top level key of the theme.json file.
- * @param {string} value The value of the key.
+ * @param {string} key      The top level key of the theme.json file.
+ * @param {string} value    The value of the key.
+ * @param {boolean} custom  If its a custom or preset value.
  * @returns {string}
  */
-module.exports = function (key, value) {
-	return `var(--wp--preset--${key}--${value})`;
+module.exports = function (key, value, custom) {
+	const type = custom ? 'custom' : 'preset';
+	return `var(--wp--${type}--${key}--${value})`;
 };

--- a/tests/themeJson.test.js
+++ b/tests/themeJson.test.js
@@ -32,7 +32,13 @@ const json = {
 			],
 			text: false,
 		},
-		custom: {},
+		custom: {
+			color: {
+				primary: '#DD93B5',
+				secondary: '#F47733',
+				tertiary: '#0F5B66',
+			},
+		},
 		layout: {
 			contentSize: '1024px',
 			wideSize: '1280px',
@@ -104,12 +110,22 @@ const json = {
 	},
 };
 
-const expected = {
+const expectedPresets = {
 	primary: 'var(--wp--preset--color--primary)',
 	secondary: 'var(--wp--preset--color--secondary)',
 	tertiary: 'var(--wp--preset--color--tertiary)',
 };
 
+const expectedCustom = {
+	primary: 'var(--wp--custom--color--primary)',
+	secondary: 'var(--wp--custom--color--secondary)',
+	tertiary: 'var(--wp--custom--color--tertiary)',
+};
+
 test('Returns a Tailwind formatted object of a theme.json setting', () => {
-	expect(themeJson('settings.color.palette', json)).toEqual(expected);
+	expect(themeJson('settings.color.palette', json)).toEqual(expectedPresets);
+});
+
+test('Returns a Tailwind formatted object of a theme.json custom setting', () => {
+	expect(themeJson('settings.custom.color', json)).toEqual(expectedCustom);
 });


### PR DESCRIPTION
Previously, yusing values from the `custom` key wasn't possible. This adds support for this as it may become advantageous to move certain settings in to custom.